### PR TITLE
Include namespace for function call because the deployed compiler doe…

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -169,14 +169,15 @@ namespace Deep
         public float LevelScore => Max[1] / RecoverMax;
 
 
-        public float EffectiveMax(float playerMaxHeath, bool hq)
+        public float EffectiveMax(float playerMaxHealth, bool hq)
         {
-            return playerMaxHeath * Rate[hq ? 1 : 0];
+            var index = hq ? 1 : 0;
+            return Math.Min(playerMaxHealth * Rate[index], Max[index]);
         }
 
-        public float EffectiveHPS(float playerMaxHeath, bool hq)
+        public float EffectiveHPS(float playerMaxHealth, bool hq)
         {
-            var effectiveMax = EffectiveMax(playerMaxHeath, hq);
+            var effectiveMax = EffectiveMax(playerMaxHealth, hq);
             float cooldown = ItemData[hq ? 1 : 0].Cooldown;
             if (hq)
                 cooldown = cooldown * .89f;

--- a/TaskManager/Actions/Loot.cs
+++ b/TaskManager/Actions/Loot.cs
@@ -122,7 +122,7 @@ namespace Deep.TaskManager.Actions
 
                     if (Core.Me.HasAura(Auras.Lust))
                     {
-                        await Common.CancelAura(Auras.Lust);
+                        await Deep.Tasks.Coroutines.Common.CancelAura(Auras.Lust);
                     }
                     Logger.Verbose("Attempting to interact with: {0} ({1} / 3)", Target.Name, tries + 1);
 


### PR DESCRIPTION
…sn't like it missing.